### PR TITLE
- Fix IE9 hack with ie9 html class

### DIFF
--- a/pieces/agent-controller/public/__/base-header.ptl
+++ b/pieces/agent-controller/public/__/base-header.ptl
@@ -14,7 +14,8 @@
 <!--[if lt IE 7]><html{$_lang} class="no-js lt-ie9 lt-ie8 lt-ie7 ie6"><![endif]-->
 <!--[if IE 7]><html{$_lang} class="no-js lt-ie9 lt-ie8 ie7"><![endif]-->
 <!--[if IE 8]><html{$_lang} class="no-js lt-ie9 ie8"><![endif]-->
-<!--[if gt IE 8]><!--><html{$_lang} class="no-js"><!--<![endif]-->
+<!--[if IE 9]><!--><html{$_lang} class="no-js ie9"><!--<![endif]-->
+<!--[if (gt IE 9)|!(IE)]><!--><html{$_lang} class="no-js"><!--<![endif]-->
 <head>
     <meta charset="utf-8">
     <script src="{base:'js/w'}"></script>


### PR DESCRIPTION
IE9 already needs to behacking, but it is not easy to find a CSS code that works only for IE9.
Here is the solution

``` css
.test {color:blue;} :root .test {color:red ; \}
```

All browsers display the text in blue except IE9 that display in red.
